### PR TITLE
docker image for automala paper

### DIFF
--- a/autoMALA/Dockerfile
+++ b/autoMALA/Dockerfile
@@ -1,0 +1,17 @@
+FROM julia:1.9.3-bookworm
+
+RUN apt-get update && apt-get install -y \
+        wget ca-certificates make g++
+
+# cmdstan
+# based on https://github.com/tpapp/cmdstan-docker/
+ENV CMDSTAN_VERSION 2.33.1
+RUN wget --progress=dot:mega "https://github.com/stan-dev/cmdstan/releases/download/v$CMDSTAN_VERSION/cmdstan-$CMDSTAN_VERSION.tar.gz" && \
+        tar -zxpf "cmdstan-$CMDSTAN_VERSION.tar.gz" && \
+        cd "cmdstan-$CMDSTAN_VERSION" && \
+        make build
+ENV CMDSTAN=/cmdstan-$CMDSTAN_VERSION
+
+# clean up to reduce image size
+RUN rm -rf /var/lib/apt/lists/*
+

--- a/autoMALA/Dockerfile
+++ b/autoMALA/Dockerfile
@@ -13,5 +13,6 @@ RUN wget --progress=dot:mega "https://github.com/stan-dev/cmdstan/releases/downl
 ENV CMDSTAN=/cmdstan-$CMDSTAN_VERSION
 
 # clean up to reduce image size
+RUN rm cmdstan-$CMDSTAN_VERSION.tar.gz
 RUN rm -rf /var/lib/apt/lists/*
 

--- a/autoMALA/README.md
+++ b/autoMALA/README.md
@@ -1,2 +1,1 @@
-A default image covering as much as possible the software requirements 
-of our nextflow scripts. 
+An image for reproducing the results of the autoMALA paper.

--- a/autoMALA/README.md
+++ b/autoMALA/README.md
@@ -1,0 +1,2 @@
+A default image covering as much as possible the software requirements 
+of our nextflow scripts. 


### PR DESCRIPTION
Starts from the public julia img and adds cmdstan. The version of cmdstan can be changed in the dockerfile. I set the env variable CMDSTAN to the correct path so that libraries using cmdstan should be able to find it.